### PR TITLE
Remove GET /credentials endpoint

### DIFF
--- a/holder.yml
+++ b/holder.yml
@@ -68,46 +68,6 @@ paths:
           description: Credential not found
         "410":
           description: Gone! There is no data here
-  /credentials:
-    get:
-      tags:
-       - Credentials
-      security:
-       - networkAuth: []
-       - oAuth2: []
-       - zCap: []
-      summary: Gets list of credentials or verifiable credentials
-      operationId: getCredentials
-      x-expectedCaller: "Holder Coordinator or Issuer Coordinator"
-      parameters:
-        - in: query
-          name: type
-          schema:
-            type: array
-            items:
-              type: string
-              pattern: "(credentials|verifiablecredentials|all)"
-      responses:
-        "200":
-          description: Credentials retrieved
-          content:
-            application/json:
-              schema:
-                type: object
-                description: The Credentials
-                properties:
-                  results:
-                    type: array
-                    items:
-                      anyOf:
-                        - $ref: "./components/VerifiableCredential.yml#/components/schemas/VerifiableCredential"
-                        - $ref: "./components/EnvelopedVerifiableCredential.yml#/components/schemas/EnvelopedVerifiableCredential"
-        "400":
-          description: Bad Request
-        "401":
-          description: Not Authorized
-        "410":
-          description: Gone! There is no data here
   /credentials/derive:
     post:
       tags:

--- a/index.html
+++ b/index.html
@@ -811,21 +811,13 @@ does not understand or know how to process.
           If a component does not have a listing below it means the VC-API does not currently specify any endpoints for that component.
         </p>
 
-      <h4>Issuer Coordinator</h4>
-      <p>
-        Below are all endpoints expected to be exposed by the Issuer Coordinator, along with the component
-        that is expected to call the endpoint
-      </p>
-      <table class="simple api-component-table"
-        data-api-path="/credentials"></table>
-
       <h4>Issuer Service</h4>
       <p>
         Below are all endpoints expected to be exposed by the Issuer Service, along with the component
         that is expected to call the endpoint
       </p>
       <table class="simple api-component-table"
-        data-api-path="/credentials/issue /credentials /credentials/{id}"></table>
+        data-api-path="/credentials/issue /credentials/{id}"></table>
 
       <h4>Status Service</h4>
       <p>

--- a/index.html
+++ b/index.html
@@ -810,7 +810,13 @@ does not understand or know how to process.
           This section gives an overview of all endpoints in the VC-API by the component the endpoint is expected be callable from.
           If a component does not have a listing below it means the VC-API does not currently specify any endpoints for that component.
         </p>
-
+      <h4>Issuer Coordinator</h4>
+      <p>
+        Below are all endpoints expected to be exposed by the Issuer Coordinator, along with the component
+        that is expected to call the endpoint
+      </p>
+      <table class="simple api-component-table"
+        data-api-path=""></table>
       <h4>Issuer Service</h4>
       <p>
         Below are all endpoints expected to be exposed by the Issuer Service, along with the component

--- a/index.html
+++ b/index.html
@@ -867,7 +867,7 @@ The following APIs are defined for issuing a Verifiable Credential:
       </p>
 
       <table class="simple api-summary-table"
-        data-api-path="/credentials /credentials/{id}
+        data-api-path="/credentials/{id}
           /credentials/issue /credentials/status"></table>
 
       <section>
@@ -883,15 +883,6 @@ The following APIs are defined for issuing a Verifiable Credential:
 
         <div class="api-detail"
           data-api-endpoint="post /credentials/issue"></div>
-      </section>
-
-      <section>
-        <h4>Get Credentials</h4>
-        <p>
-        </p>
-
-        <div class="api-detail"
-          data-api-endpoint="get /credentials"></div>
       </section>
 
       <section>


### PR DESCRIPTION
Issuing Section - 
Removing the `Get /credentials` endpoint from the specification.

Issue https://github.com/w3c-ccg/vc-api/issues/302