### PR TITLE
rename path parameters to use consistent PathId naming convention

### DIFF
--- a/components/parameters/path/ExchangePathId.yml
+++ b/components/parameters/path/ExchangePathId.yml
@@ -1,0 +1,7 @@
+name: exchangePathId
+description: A path-specific (local) identifier for an exchange instance. This is a local identifier that is meaningful only within the context of this API endpoint path, not a globally unique identifier.
+in: path
+required: true
+schema:
+  type: string
+  pattern: "[a-z0-9][a-z0-9\\-]{2,}"

--- a/components/parameters/path/LocalExchangeId.yml
+++ b/components/parameters/path/LocalExchangeId.yml
@@ -1,7 +1,0 @@
-name: localExchangeId
-description: A local identifier for an exchange instance.
-in: path
-required: true
-schema:
-  type: string
-  pattern: "[a-z0-9][a-z0-9\\-]{2,}"

--- a/components/parameters/path/LocalWorkflowId.yml
+++ b/components/parameters/path/LocalWorkflowId.yml
@@ -1,7 +1,0 @@
-name: localWorkflowId
-description: A local identifier for a workflow instance.
-in: path
-required: true
-schema:
-  type: string
-  pattern: "[a-z0-9][a-z0-9\\-]{2,}"

--- a/components/parameters/path/WorkflowPathId.yml
+++ b/components/parameters/path/WorkflowPathId.yml
@@ -1,0 +1,7 @@
+name: workflowPathId
+description: A path-specific (local) identifier for a workflow instance. This is a local identifier that is meaningful only within the context of this API endpoint path, not a globally unique identifier.
+in: path
+required: true
+schema:
+  type: string
+  pattern: "[a-z0-9][a-z0-9\\-]{2,}"

--- a/exchanges.yml
+++ b/exchanges.yml
@@ -55,7 +55,7 @@ paths:
           description: Not Authorized
         "500":
           description: Internal Error
-  /workflows/{localWorkflowId}:
+  /workflows/{workflowPathId}:
     get:
       summary: Gets the configuration of an existing workflow and returns it in the response body.
       tags:
@@ -68,7 +68,7 @@ paths:
       description: Gets the configuration of an existing workflow and returns it in the response body.
       x-expectedCaller: Administrators
       parameters:
-        - $ref: "./components/parameters/path/LocalWorkflowId.yml"
+        - $ref: "./components/parameters/path/WorkflowPathId.yml"
       responses:
         "200":
           description: Workflow configuration retrieved!
@@ -82,7 +82,7 @@ paths:
           description: Not Authorized
         "500":
           description: Internal Error
-  /workflows/{localWorkflowId}/exchanges:
+  /workflows/{workflowPathId}/exchanges:
     post:
       summary: Creates a new exchange and returns location of exchange metadata in a response header.
       tags:
@@ -95,7 +95,7 @@ paths:
       description: Creates a new exchange and returns location of exchange metadata in a response header.
       x-expectedCaller: Owner Coordinator
       parameters:
-        - $ref: "./components/parameters/path/LocalWorkflowId.yml"
+        - $ref: "./components/parameters/path/WorkflowPathId.yml"
       requestBody:
         content:
           application/json:
@@ -126,7 +126,7 @@ paths:
           description: Not Authorized
         "500":
           description: Internal Error
-  /workflows/{localWorkflowId}/exchanges/{localExchangeId}:
+  /workflows/{workflowPathId}/exchanges/{exchangePathId}:
     get:
       summary: Gets the state of an existing exchange and returns it in the response body.
       tags:
@@ -139,8 +139,8 @@ paths:
       description: Gets the configuration of an existing exchange and returns it in the response body.
       x-expectedCaller: Owner Coordinator
       parameters:
-        - $ref: "./components/parameters/path/LocalWorkflowId.yml"
-        - $ref: "./components/parameters/path/LocalExchangeId.yml"
+        - $ref: "./components/parameters/path/WorkflowPathId.yml"
+        - $ref: "./components/parameters/path/ExchangePathId.yml"
       responses:
         "200":
           description: Exchange configuration retrieved!
@@ -170,8 +170,8 @@ paths:
       description: Participate in an exchange. Posting an empty body will start the exchange or return what the exchange is expecting to complete the next step.
       x-expectedCaller: Anyone
       parameters:
-        - $ref: "./components/parameters/path/LocalWorkflowId.yml"
-        - $ref: "./components/parameters/path/LocalExchangeId.yml"
+        - $ref: "./components/parameters/path/WorkflowPathId.yml"
+        - $ref: "./components/parameters/path/ExchangePathId.yml"
       requestBody:
         content:
           application/json:

--- a/index.html
+++ b/index.html
@@ -858,7 +858,7 @@ does not understand or know how to process.
         that is expected to call the endpoint
       </p>
       <table class="simple api-component-table"
-        data-api-path="/workflows /workflows/{localWorkflowId} /workflows/{localWorkflowId}/exchanges /workflows/{localWorkflowId}/exchanges/{localExchangeId}"></table>
+        data-api-path="/workflows /workflows/{workflowPathId} /workflows/{workflowPathId}/exchanges /workflows/{workflowPathId}/exchanges/{exchangePathId}"></table>
 
     </section>
     <section>
@@ -1251,12 +1251,12 @@ The following APIs are defined for using workflows and exchanges for credential 
       </p>
 
       <table class="simple api-summary-table"
-        data-api-path="/workflows /workflows/{localWorkflowId} /workflows/{localWorkflowId}/exchanges /workflows/{localWorkflowId}/exchanges/{localExchangeId}"></table>
+        data-api-path="/workflows /workflows/{workflowPathId} /workflows/{workflowPathId}/exchanges /workflows/{workflowPathId}/exchanges/{exchangePathId}"></table>
 
-      <p>
+      <p class="note" title="Path Identifier (PathId) Convention">
 In the workflows and exchanges APIs, a "local" ID refers to an ID that is local to a service instance.
 In other words, an `exchangeId` or `workflowId` refers to a fully qualified URL,
-while a `localExchangeId` or `localWorkflowId` refers to a specific element in the URL path.
+while a `exchangePathId` or `workflowPathId` refers to a specific element in the URL path.
       </p>
 
       <section>
@@ -1274,10 +1274,10 @@ while a `localExchangeId` or `localWorkflowId` refers to a specific element in t
         </p>
 
         <div class="api-detail"
-          data-api-endpoint="get /workflows/{localWorkflowId}"></div>
+          data-api-endpoint="get /workflows/{workflowPathId}"></div>
       </section>
       <p>
-There is an `expires` property associated with exchanges, denoting the expiration date and time of the exchange. It is created using the /workflows/{localWorkflowId}/exchanges
+There is an `expires` property associated with exchanges, denoting the expiration date and time of the exchange. It is created using the /workflows/{workflowPathId}/exchanges
 endpoint. This impacts the lifetime of challenges associated with such an exchange: if a
 challenge is bound to an exchange, that challenge ceases to be valid at the date referenced by the `expires` property of the exchange.
       </p>
@@ -1287,7 +1287,7 @@ challenge is bound to an exchange, that challenge ceases to be valid at the date
         </p>
 
         <div class="api-detail"
-          data-api-endpoint="post /workflows/{localWorkflowId}/exchanges"></div>
+          data-api-endpoint="post /workflows/{workflowPathId}/exchanges"></div>
       </section>
 
       <section>
@@ -1296,7 +1296,7 @@ challenge is bound to an exchange, that challenge ceases to be valid at the date
         </p>
 
         <div class="api-detail"
-          data-api-endpoint="post /workflows/{localWorkflowId}/exchanges/{localExchangeId}"></div>
+          data-api-endpoint="post /workflows/{workflowPathId}/exchanges/{exchangePathId}"></div>
       </section>
 
       <section>
@@ -1305,7 +1305,7 @@ challenge is bound to an exchange, that challenge ceases to be valid at the date
         </p>
 
         <div class="api-detail"
-          data-api-endpoint="get /workflows/{localWorkflowId}/exchanges/{localExchangeId}"></div>
+          data-api-endpoint="get /workflows/{workflowPathId}/exchanges/{exchangePathId}"></div>
       </section>
 
 


### PR DESCRIPTION
## 📋 Changes Made
- Rename `localWorkflowId` → `workflowPathId` in all references
- Rename `localExchangeId` → `exchangePathId` in all references  
- Update parameter descriptions to clarify path-specific scope
- Update API documentation paths in index.html

Addresses issue #412 - Making the naming scheme for path parameters consistent.

## 🔧 Files Changed
- `components/parameters/path/LocalWorkflowId.yml` → `WorkflowPathId.yml` (file name changed as well)
- `components/parameters/path/LocalExchangeId.yml` → `ExchangePathId.yml` (file name changed as well)
- `exchanges.yml`
- `index.html`